### PR TITLE
Mount  config from the host

### DIFF
--- a/docker/pypi/wmagent-couchdb/Dockerfile
+++ b/docker/pypi/wmagent-couchdb/Dockerfile
@@ -50,7 +50,7 @@ ADD manage ${COUCH_MANAGE_DIR}/manage
 RUN ln -s ${COUCH_MANAGE_DIR}/manage ${COUCH_ROOT_DIR}/manage
 
 # The $COUCH_CONFIG_DIR is to be mounted from the host and locla.ini read from there
-ADD local.ini ${COUCH_CONFIG_DIR}/local.ini
+ADD local.ini ${COUCH_DEPLOY_DIR}/local.ini
 RUN ln -s ${COUCH_CONFIG_DIR}/local.ini /opt/couchdb/etc/local.d/
 
 ENV PATH="/opt/couchdb/bin:/usr/local/bin/:${PATH}"

--- a/docker/pypi/wmagent-couchdb/Dockerfile
+++ b/docker/pypi/wmagent-couchdb/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get install -y hostname net-tools iputils-ping procps emacs-nox tcpdump 
 
 RUN pip install CMSCouchapp
 
+ENV COUCH_PORT=5984
 ENV COUCH_ROOT_DIR=/data
 
 ENV COUCH_BASE_DIR=$COUCH_ROOT_DIR/srv/couchdb

--- a/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
+++ b/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
@@ -75,7 +75,7 @@ groupEntry=$(getent group $thisGroup)
 
 [[ -d $HOST_MOUNT_DIR/certs ]] || mkdir -p $HOST_MOUNT_DIR/certs || exit $?
 [[ -d $HOST_MOUNT_DIR/admin/couchdb ]] || mkdir -p $HOST_MOUNT_DIR/admin/couchdb || exit $?
-# [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  || exit $?
+[[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs || exit $?
 
@@ -91,6 +91,7 @@ dockerOpts="
 --mount type=bind,source=$HOST_MOUNT_DIR/certs,target=/data/certs \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database,target=/data/srv/couchdb/current/install/database \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs,target=/data/srv/couchdb/current/logs \
+--mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config,target=/data/srv/couchdb/current/config \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/couchdb,target=/data/admin/couchdb/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/passwd,target=/etc/passwd,readonly \

--- a/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
+++ b/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
@@ -78,6 +78,7 @@ groupEntry=$(getent group $thisGroup)
 [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs || exit $?
+[[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/state ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/state || exit $?
 
 
 dockerOpts="
@@ -89,8 +90,9 @@ dockerOpts="
 --name=couchdb \
 --mount type=bind,source=/tmp,target=/tmp \
 --mount type=bind,source=$HOST_MOUNT_DIR/certs,target=/data/certs \
---mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database,target=/data/srv/couchdb/current/install/database \
+--mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install,target=/data/srv/couchdb/current/install \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs,target=/data/srv/couchdb/current/logs \
+--mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/state,target=/data/srv/couchdb/current/state \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config,target=/data/srv/couchdb/current/config \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/couchdb,target=/data/admin/couchdb/ \
@@ -101,6 +103,7 @@ dockerOpts="
 "
 
 # --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config,target=/data/srv/couchdb/current/config \
+# --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database,target=/data/srv/couchdb/current/install/database \
 
 registry=local
 repository=wmagent-couchdb

--- a/docker/pypi/wmagent-couchdb/manage
+++ b/docker/pypi/wmagent-couchdb/manage
@@ -680,6 +680,8 @@ init_couchdb() {
     # i.e. check if COUCHDB_SECRETS_FILE and WMAGENT_SECRETS_FILE from the host
     # have been parsed correctly and the passwords propagated to local.ini
 
+    [[ -f $COUCH_CONFIG_DIR/local.ini ]] || cp -v $COUCH_DEPLOY_DIR/local.ini $COUCH_CONFIG_DIR/local.ini
+
     # First check if all variables in the local.ini file are properly set
     local parseOk=true
     _parse_localini $COUCH_CONFIG_DIR/local.ini || parseOk=false


### PR DESCRIPTION
Fixing User permissions for the CouchDB container

With the current PR we I am suggesting to mount  the config area from the host at startup, this way the `local.ini`  file will be copied  if missing at the host with the proper user permissions, and the initialization process  is now completing correctly. 